### PR TITLE
🐛 Fix: 자체 회원가입, 로그인 수정

### DIFF
--- a/src/main/java/com/skhu/moodfriend/app/controller/auth/AuthController.java
+++ b/src/main/java/com/skhu/moodfriend/app/controller/auth/AuthController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
-@Tag(name = "회원가입/로그인", description = "회원가입/로그인을 담당하는 api 그룹")
+@Tag(name = "자체 회원가입/로그인", description = "자체 회원가입/로그인을 담당하는 api 그룹")
 @RequestMapping("/api/v1/auth")
 public class AuthController {
 

--- a/src/main/java/com/skhu/moodfriend/app/dto/auth/reqDto/SignUpReqDto.java
+++ b/src/main/java/com/skhu/moodfriend/app/dto/auth/reqDto/SignUpReqDto.java
@@ -3,8 +3,7 @@ package com.skhu.moodfriend.app.dto.auth.reqDto;
 public record SignUpReqDto(
         String email,
         String password,
-        String name,
-        String loginType,
-        String roleType
+        String confirmPassword,
+        String name
 ) {
 }

--- a/src/main/java/com/skhu/moodfriend/app/dto/auth/reqDto/SignUpReqDto.java
+++ b/src/main/java/com/skhu/moodfriend/app/dto/auth/reqDto/SignUpReqDto.java
@@ -3,7 +3,6 @@ package com.skhu.moodfriend.app.dto.auth.reqDto;
 public record SignUpReqDto(
         String email,
         String password,
-        String confirmPassword,
-        String name
+        String confirmPassword
 ) {
 }

--- a/src/main/java/com/skhu/moodfriend/app/service/auth/SignUpService.java
+++ b/src/main/java/com/skhu/moodfriend/app/service/auth/SignUpService.java
@@ -28,7 +28,7 @@ public class SignUpService {
     private final TokenProvider tokenProvider;
 
     private static final String EMAIL_REGEX = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$";
-    private static final String PASSWORD_REGEX = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{10,16}$";
+    private static final String PASSWORD_REGEX = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*])[A-Za-z\\d!@#$%^&*]{10,16}$";
 
     @Transactional
     public ApiResponseTemplate<SignUpResDto> signUp(SignUpReqDto signUpReqDto) {

--- a/src/main/java/com/skhu/moodfriend/app/service/auth/SignUpService.java
+++ b/src/main/java/com/skhu/moodfriend/app/service/auth/SignUpService.java
@@ -54,7 +54,7 @@ public class SignUpService {
         Member member = memberRepository.save(Member.builder()
                 .email(signUpReqDto.email())
                 .password(encodePassword)
-                .name(signUpReqDto.name())
+                .name("호야집사")
                 .mileage(0)
                 .emotionType(EmotionType.SO_SO)
                 .loginType(LoginType.NATIVE_LOGIN)

--- a/src/main/java/com/skhu/moodfriend/app/service/auth/SignUpService.java
+++ b/src/main/java/com/skhu/moodfriend/app/service/auth/SignUpService.java
@@ -2,10 +2,7 @@ package com.skhu.moodfriend.app.service.auth;
 
 import com.skhu.moodfriend.app.dto.auth.reqDto.SignUpReqDto;
 import com.skhu.moodfriend.app.dto.auth.resDto.SignUpResDto;
-import com.skhu.moodfriend.app.entity.member.LoginType;
-import com.skhu.moodfriend.app.entity.member.Member;
-import com.skhu.moodfriend.app.entity.member.MemberRefreshToken;
-import com.skhu.moodfriend.app.entity.member.RoleType;
+import com.skhu.moodfriend.app.entity.member.*;
 import com.skhu.moodfriend.app.repository.MemberRefreshTokenRepository;
 import com.skhu.moodfriend.app.repository.MemberRepository;
 import com.skhu.moodfriend.global.exception.CustomException;
@@ -44,26 +41,28 @@ public class SignUpService {
             throw new CustomException(ErrorCode.INVALID_PASSWORD_FORMAT_EXCEPTION, ErrorCode.INVALID_PASSWORD_FORMAT_EXCEPTION.getMessage());
         }
 
-        String encodePassword = passwordEncoder.encode(signUpReqDto.password());
+        if (!signUpReqDto.password().equals(signUpReqDto.confirmPassword())) {
+            throw new CustomException(ErrorCode.PASSWORD_MISMATCH_EXCEPTION, ErrorCode.PASSWORD_MISMATCH_EXCEPTION.getMessage());
+        }
 
         if (memberRepository.existsByEmail(signUpReqDto.email())) {
             throw new CustomException(ErrorCode.ALREADY_EXIST_USER_EXCEPTION, ErrorCode.ALREADY_EXIST_USER_EXCEPTION.getMessage());
         }
 
-        LoginType loginType = LoginType.getLoginTypeOfString(signUpReqDto.loginType());
-        RoleType roleType = RoleType.getRoleTypeOfString(signUpReqDto.roleType());
+        String encodePassword = passwordEncoder.encode(signUpReqDto.password());
 
         Member member = memberRepository.save(Member.builder()
                 .email(signUpReqDto.email())
                 .password(encodePassword)
                 .name(signUpReqDto.name())
-                .loginType(loginType)
-                .roleType(roleType)
+                .mileage(0)
+                .emotionType(EmotionType.SO_SO)
+                .loginType(LoginType.NATIVE_LOGIN)
+                .roleType(RoleType.ROLE_USER)
                 .build()
         );
 
         String accessToken = tokenProvider.createAccessToken(member);
-
         String refreshToken = tokenProvider.createRefreshToken(member);
 
         MemberRefreshToken memberRefreshToken = new MemberRefreshToken();
@@ -71,7 +70,6 @@ public class SignUpService {
         memberRefreshToken.setMember(member);
 
         memberRefreshTokenRepository.deleteByMember(member);
-
         memberRefreshTokenRepository.save(memberRefreshToken);
 
         SignUpResDto resDto = SignUpResDto.builder()

--- a/src/main/java/com/skhu/moodfriend/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/skhu/moodfriend/global/exception/code/ErrorCode.java
@@ -25,7 +25,7 @@ public enum ErrorCode {
     FAIL_ENCODING_IMAGE_FILE_NAME(HttpStatus.BAD_REQUEST, "파일명 인코딩에 실패했습니다."),
     INVALID_FILE_TYPE_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 형식의 파일입니다."),
     INVALID_EMAIL_FORMAT_EXCEPTION(HttpStatus.BAD_REQUEST, "이메일 형식에 알맞지 않습니다."),
-    INVALID_PASSWORD_FORMAT_EXCEPTION(HttpStatus.BAD_REQUEST, "영문, 숫자 조합의 10자 이상 16자 이하여야 합니다."),
+    INVALID_PASSWORD_FORMAT_EXCEPTION(HttpStatus.BAD_REQUEST, "영문, 숫자, 특수문자 조합의 10자 이상 16자 이하여야 합니다."),
 
     // 401 Unauthorized
     UNAUTHORIZED_EMAIL_EXCEPTION(HttpStatus.UNAUTHORIZED, "이메일 인증이 필요합니다."),

--- a/src/main/java/com/skhu/moodfriend/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/skhu/moodfriend/global/exception/code/ErrorCode.java
@@ -11,7 +11,7 @@ public enum ErrorCode {
 
     // 400 Bad Request
     VALIDATION_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
-    PASSWORD_MISMATCH_EXCEPTION(HttpStatus.BAD_REQUEST,"잘못된 비밀번호가 입력되었습니다."),
+    PASSWORD_MISMATCH_EXCEPTION(HttpStatus.BAD_REQUEST,"비밀번호가 일치하지 않습니다."),
     VALIDATION_REQUEST_MISSING_EXCEPTION(HttpStatus.BAD_REQUEST, "필수적인 요청 값이 입력되지 않았습니다."),
     VALIDATION_REQUEST_HEADER_MISSING_EXCEPTION(HttpStatus.BAD_REQUEST, "요청 헤더값이 입력되지 않았습니다."),
     VALIDATION_REQUEST_PARAMETER_MISSING_EXCEPTION(HttpStatus.BAD_REQUEST, "요청 파라미터값이 입력되지 않았습니다."),
@@ -24,8 +24,8 @@ public enum ErrorCode {
     INVALID_DISPLAY_NAME_EXCEPTION(HttpStatus.BAD_REQUEST, "유효하지 않은 displayName이 있습니다 "),
     FAIL_ENCODING_IMAGE_FILE_NAME(HttpStatus.BAD_REQUEST, "파일명 인코딩에 실패했습니다."),
     INVALID_FILE_TYPE_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 형식의 파일입니다."),
-    INVALID_EMAIL_FORMAT_EXCEPTION(HttpStatus.BAD_REQUEST, "이메일 형식이 유효하지 않습니다."),
-    INVALID_PASSWORD_FORMAT_EXCEPTION(HttpStatus.BAD_REQUEST, "비밀번호는 영문자, 숫자 조합의 10자 이상 16자 이하이어야 합니다."),
+    INVALID_EMAIL_FORMAT_EXCEPTION(HttpStatus.BAD_REQUEST, "이메일 형식에 알맞지 않습니다."),
+    INVALID_PASSWORD_FORMAT_EXCEPTION(HttpStatus.BAD_REQUEST, "영문, 숫자 조합의 10자 이상 16자 이하여야 합니다."),
 
     // 401 Unauthorized
     UNAUTHORIZED_EMAIL_EXCEPTION(HttpStatus.UNAUTHORIZED, "이메일 인증이 필요합니다."),


### PR DESCRIPTION
## 🍀 관련 이슈

- Resolved: #9


## 🌱 작업 내용

- 회원가입에서 비밀번호 재확인 필드 추가
- 이름 필드 디폴트값으로 처리, 그외 에러 메시지 수정


<img width="1000" alt="회원가입_이메일 형식" src="https://github.com/user-attachments/assets/75a4d0cf-8c29-449f-8d69-559d191bd8fe">

<img width="1000" alt="회원가입_비밀번호 형식" src="https://github.com/user-attachments/assets/f740f1d5-6446-4811-b53c-afdf485d3898">

<img width="1000" alt="회원가입_비밀번호 재확인" src="https://github.com/user-attachments/assets/62db0870-1473-489d-bc67-15e5042e8e76">

<img width="1000" alt="회원가입 성공" src="https://github.com/user-attachments/assets/90b085e0-1d2b-4624-8786-b7e160c58043">

<img width="1000" alt="로그인 실패" src="https://github.com/user-attachments/assets/de446606-64fe-4088-9966-6f02d47a4cd8">

<img width="1000" alt="로그인 성공" src="https://github.com/user-attachments/assets/6c7a0995-d8c8-44aa-82ac-a17aae60419b">



## 💬 리뷰 요구사항

- 피그마, 로직 살펴보고 수정이 필요한 부분이 있는지 체크해줘!
