### PR TITLE
Feat: AI 일기 조회, 삭제 구현

### DIFF
--- a/src/main/java/com/skhu/moodfriend/app/controller/tracker/DiaryAIController.java
+++ b/src/main/java/com/skhu/moodfriend/app/controller/tracker/DiaryAIController.java
@@ -1,0 +1,39 @@
+package com.skhu.moodfriend.app.controller.tracker;
+
+import com.skhu.moodfriend.app.service.tracker.DiaryAIModifyService;
+import com.skhu.moodfriend.global.template.ApiResponseTemplate;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@Tag(name = "AI 일기 삭제", description = "AI 일기를 삭제하는 api 그룹")
+@RequestMapping("/api/v1/diary/ai")
+public class DiaryAIController {
+
+    private final DiaryAIModifyService diaryAIModifyService;
+
+    @DeleteMapping("delete/{diaryAIId}")
+    @Operation(
+            summary = "사용자 AI 일기 삭제",
+            description = "사용자 AI 일기를 삭제합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "사용자 AI 일기 삭제 성공"),
+                    @ApiResponse(responseCode = "403", description = "권한 문제 or 관리자 문의"),
+                    @ApiResponse(responseCode = "404", description = "해당 AI 일기를 찾을 수 없음"),
+                    @ApiResponse(responseCode = "500", description = "서버 문제 or 관리자 문의")
+            }
+    )
+    public ResponseEntity<ApiResponseTemplate<Void>> deleteDiaryAI(
+            @PathVariable Long diaryAIId,
+            @RequestParam Long memberId) {
+
+        ApiResponseTemplate<Void> data = diaryAIModifyService.deleteDiaryAI(diaryAIId, memberId);
+        return ResponseEntity.status(data.getStatus()).body(data);
+    }
+}

--- a/src/main/java/com/skhu/moodfriend/app/controller/tracker/DiaryAIDisplayController.java
+++ b/src/main/java/com/skhu/moodfriend/app/controller/tracker/DiaryAIDisplayController.java
@@ -9,10 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -23,6 +20,25 @@ import java.util.List;
 public class DiaryAIDisplayController {
 
     private final DiaryAIDisplayService diaryAIDisplayService;
+
+    @GetMapping("/{diaryAIId}")
+    @Operation(
+            summary = "사용자의 특정 AI 일기 조회",
+            description = "사용자의 특정 AI 일기를 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "AI 일기 조회 성공"),
+                    @ApiResponse(responseCode = "403", description = "권한 문제 or 관리자 문의"),
+                    @ApiResponse(responseCode = "404", description = "해당 AI 일기를 찾을 수 없음"),
+                    @ApiResponse(responseCode = "500", description = "서버 문제 or 관리자 문의")
+            }
+    )
+    public ResponseEntity<ApiResponseTemplate<DiaryAIResDto>> getDiarySummaryById(
+            @PathVariable Long diaryAIId,
+            @RequestParam Long memberId) {
+
+        ApiResponseTemplate<DiaryAIResDto> data = diaryAIDisplayService.getDiarySummaryById(diaryAIId, memberId);
+        return ResponseEntity.status(data.getStatus()).body(data);
+    }
 
     @GetMapping
     @Operation(

--- a/src/main/java/com/skhu/moodfriend/app/controller/tracker/DiaryAIDisplayController.java
+++ b/src/main/java/com/skhu/moodfriend/app/controller/tracker/DiaryAIDisplayController.java
@@ -1,0 +1,42 @@
+package com.skhu.moodfriend.app.controller.tracker;
+
+import com.skhu.moodfriend.app.dto.tracker.resDto.DiaryAIResDto;
+import com.skhu.moodfriend.app.service.tracker.DiaryAIDisplayService;
+import com.skhu.moodfriend.global.template.ApiResponseTemplate;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@Tag(name = "AI 일기 조회", description = "AI 일기를 조회하는 api 그룹")
+@RequestMapping("/api/v1/diary/ai/display")
+public class DiaryAIDisplayController {
+
+    private final DiaryAIDisplayService diaryAIDisplayService;
+
+    @GetMapping
+    @Operation(
+            summary = "사용자의 모든 AI 일기 조회",
+            description = "사용자의 모든 AI 일기를 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "AI 일기 목록 조회 성공"),
+                    @ApiResponse(responseCode = "403", description = "권한 문제 or 관리자 문의"),
+                    @ApiResponse(responseCode = "500", description = "서버 문제 or 관리자 문의")
+            }
+    )
+    public ResponseEntity<ApiResponseTemplate<List<DiaryAIResDto>>> getAllDiaryAISummariesByUser(@RequestParam Long memberId) {
+
+        ApiResponseTemplate<List<DiaryAIResDto>> data = diaryAIDisplayService.getAllDiarySummariesByMember(memberId);
+        return ResponseEntity.status(data.getStatus()).body(data);
+    }
+}

--- a/src/main/java/com/skhu/moodfriend/app/dto/tracker/resDto/DiaryAIResDto.java
+++ b/src/main/java/com/skhu/moodfriend/app/dto/tracker/resDto/DiaryAIResDto.java
@@ -1,0 +1,15 @@
+package com.skhu.moodfriend.app.dto.tracker.resDto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record DiaryAIResDto(
+        Long diaryAIId,
+        @JsonFormat(pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+        LocalDate createdAt,
+        String summary
+) {
+}

--- a/src/main/java/com/skhu/moodfriend/app/repository/DiaryAIRepository.java
+++ b/src/main/java/com/skhu/moodfriend/app/repository/DiaryAIRepository.java
@@ -1,5 +1,6 @@
 package com.skhu.moodfriend.app.repository;
 
+import com.skhu.moodfriend.app.entity.member.Member;
 import com.skhu.moodfriend.app.entity.tracker.diary_ai.DiaryAI;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,4 +10,6 @@ import java.util.List;
 public interface DiaryAIRepository extends JpaRepository<DiaryAI, Long> {
 
     List<DiaryAI> findAllByCreatedAt(LocalDate createdAt);
+
+    List<DiaryAI> findByMemberOrderByCreatedAt(Member member);
 }

--- a/src/main/java/com/skhu/moodfriend/app/service/tracker/DiaryAIDisplayService.java
+++ b/src/main/java/com/skhu/moodfriend/app/service/tracker/DiaryAIDisplayService.java
@@ -25,6 +25,26 @@ public class DiaryAIDisplayService {
     private final DiaryAIRepository diaryAIRepository;
     private final MemberRepository memberRepository;
 
+    public ApiResponseTemplate<DiaryAIResDto> getDiarySummaryById(Long diaryAIId, Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_MEMBER_EXCEPTION, ErrorCode.NOT_FOUND_MEMBER_EXCEPTION.getMessage()));
+
+        DiaryAI diaryAI = diaryAIRepository.findById(diaryAIId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_DIARY_EXCEPTION, ErrorCode.NOT_FOUND_DIARY_EXCEPTION.getMessage()));
+
+        if (!diaryAI.getMember().equals(member)) {
+            throw new CustomException(ErrorCode.ONLY_OWN_DIARY_ACCESS_EXCEPTION, ErrorCode.ONLY_OWN_DIARY_ACCESS_EXCEPTION.getMessage());
+        }
+
+        DiaryAIResDto resDto = DiaryAIResDto.builder()
+                .diaryAIId(diaryAI.getDiaryAIId())
+                .createdAt(diaryAI.getCreatedAt())
+                .summary(diaryAI.getSummary())
+                .build();
+
+        return ApiResponseTemplate.success(SuccessCode.GET_DIARY_SUMMARY_SUCCESS, resDto);
+    }
+
     public ApiResponseTemplate<List<DiaryAIResDto>> getAllDiarySummariesByMember(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_MEMBER_EXCEPTION, ErrorCode.NOT_FOUND_MEMBER_EXCEPTION.getMessage()));

--- a/src/main/java/com/skhu/moodfriend/app/service/tracker/DiaryAIDisplayService.java
+++ b/src/main/java/com/skhu/moodfriend/app/service/tracker/DiaryAIDisplayService.java
@@ -1,0 +1,44 @@
+package com.skhu.moodfriend.app.service.tracker;
+
+import com.skhu.moodfriend.app.dto.tracker.resDto.DiaryAIResDto;
+import com.skhu.moodfriend.app.entity.member.Member;
+import com.skhu.moodfriend.app.entity.tracker.diary_ai.DiaryAI;
+import com.skhu.moodfriend.app.repository.DiaryAIRepository;
+import com.skhu.moodfriend.app.repository.MemberRepository;
+import com.skhu.moodfriend.global.exception.CustomException;
+import com.skhu.moodfriend.global.exception.code.ErrorCode;
+import com.skhu.moodfriend.global.exception.code.SuccessCode;
+import com.skhu.moodfriend.global.template.ApiResponseTemplate;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class DiaryAIDisplayService {
+
+    private final DiaryAIRepository diaryAIRepository;
+    private final MemberRepository memberRepository;
+
+    public ApiResponseTemplate<List<DiaryAIResDto>> getAllDiarySummariesByMember(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_MEMBER_EXCEPTION, ErrorCode.NOT_FOUND_MEMBER_EXCEPTION.getMessage()));
+
+        List<DiaryAI> diaryAIs = diaryAIRepository.findByMemberOrderByCreatedAt(member);
+
+        List<DiaryAIResDto> resDtos = diaryAIs.stream()
+                .map(diaryAI -> DiaryAIResDto.builder()
+                        .diaryAIId(diaryAI.getDiaryAIId())
+                        .createdAt(diaryAI.getCreatedAt())
+                        .summary(diaryAI.getSummary())
+                        .build())
+                .collect(Collectors.toList());
+
+        return ApiResponseTemplate.success(SuccessCode.GET_ALL_DIARY_SUMMARIES_SUCCESS, resDtos);
+    }
+}

--- a/src/main/java/com/skhu/moodfriend/app/service/tracker/DiaryAIModifyService.java
+++ b/src/main/java/com/skhu/moodfriend/app/service/tracker/DiaryAIModifyService.java
@@ -1,6 +1,5 @@
 package com.skhu.moodfriend.app.service.tracker;
 
-import com.skhu.moodfriend.app.dto.tracker.resDto.DiaryAIResDto;
 import com.skhu.moodfriend.app.entity.member.Member;
 import com.skhu.moodfriend.app.entity.tracker.diary_ai.DiaryAI;
 import com.skhu.moodfriend.app.repository.DiaryAIRepository;
@@ -14,18 +13,16 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
-public class DiaryAIDisplayService {
+public class DiaryAIModifyService {
 
     private final DiaryAIRepository diaryAIRepository;
     private final MemberRepository memberRepository;
 
-    public ApiResponseTemplate<DiaryAIResDto> getDiarySummaryById(
+    @Transactional
+    public ApiResponseTemplate<Void> deleteDiaryAI(
             Long diaryAIId,
             Long memberId) {
 
@@ -39,30 +36,8 @@ public class DiaryAIDisplayService {
             throw new CustomException(ErrorCode.ONLY_OWN_DIARY_ACCESS_EXCEPTION, ErrorCode.ONLY_OWN_DIARY_ACCESS_EXCEPTION.getMessage());
         }
 
-        DiaryAIResDto resDto = DiaryAIResDto.builder()
-                .diaryAIId(diaryAI.getDiaryAIId())
-                .createdAt(diaryAI.getCreatedAt())
-                .summary(diaryAI.getSummary())
-                .build();
+        diaryAIRepository.delete(diaryAI);
 
-        return ApiResponseTemplate.success(SuccessCode.GET_DIARY_SUMMARY_SUCCESS, resDto);
-    }
-
-    public ApiResponseTemplate<List<DiaryAIResDto>> getAllDiarySummariesByMember(Long memberId) {
-
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_MEMBER_EXCEPTION, ErrorCode.NOT_FOUND_MEMBER_EXCEPTION.getMessage()));
-
-        List<DiaryAI> diaryAIs = diaryAIRepository.findByMemberOrderByCreatedAt(member);
-
-        List<DiaryAIResDto> resDtos = diaryAIs.stream()
-                .map(diaryAI -> DiaryAIResDto.builder()
-                        .diaryAIId(diaryAI.getDiaryAIId())
-                        .createdAt(diaryAI.getCreatedAt())
-                        .summary(diaryAI.getSummary())
-                        .build())
-                .collect(Collectors.toList());
-
-        return ApiResponseTemplate.success(SuccessCode.GET_ALL_DIARY_SUMMARIES_SUCCESS, resDtos);
+        return ApiResponseTemplate.success(SuccessCode.DELETE_DIARY_SUCCESS, null);
     }
 }

--- a/src/main/java/com/skhu/moodfriend/global/exception/code/SuccessCode.java
+++ b/src/main/java/com/skhu/moodfriend/global/exception/code/SuccessCode.java
@@ -22,6 +22,7 @@ public enum SuccessCode {
     GET_MONTHLY_EMOTION_TYPES_SUCCESS(HttpStatus.OK, "월별 감정 리스트 조회에 성공했습니다."),
     GET_HOSPITALS_SUCCESS(HttpStatus.OK, "의료기관 조회에 성공했습니다."),
     GET_HOYA_SUCCESS(HttpStatus.OK, "챗봇 응답을 성공적으로 가져왔습니다."),
+    GET_DIARY_SUMMARY_SUCCESS(HttpStatus.OK, "일기 AI 조회에 성공했습니다."),
     GET_ALL_DIARY_SUMMARIES_SUCCESS(HttpStatus.OK, "모든 일기 AI 조회에 성공했습니다."),
 
     // 201 Created

--- a/src/main/java/com/skhu/moodfriend/global/exception/code/SuccessCode.java
+++ b/src/main/java/com/skhu/moodfriend/global/exception/code/SuccessCode.java
@@ -22,6 +22,7 @@ public enum SuccessCode {
     GET_MONTHLY_EMOTION_TYPES_SUCCESS(HttpStatus.OK, "월별 감정 리스트 조회에 성공했습니다."),
     GET_HOSPITALS_SUCCESS(HttpStatus.OK, "의료기관 조회에 성공했습니다."),
     GET_HOYA_SUCCESS(HttpStatus.OK, "챗봇 응답을 성공적으로 가져왔습니다."),
+    GET_ALL_DIARY_SUMMARIES_SUCCESS(HttpStatus.OK, "모든 일기 AI 조회에 성공했습니다."),
 
     // 201 Created
     CREATE_MEMBER_SUCCESS(HttpStatus.CREATED, "회원가입에 성공했습니다."),


### PR DESCRIPTION
## 🍀 관련 이슈

- Resolved: #37


## 🌱 작업 내용

- AI 일기 조회, 삭제 구현

<img width="1440" alt="모든 AI 일기 조회" src="https://github.com/user-attachments/assets/e26db062-e235-4ad5-859e-66540f36f320">

<img width="1440" alt="특정 AI 일기 조회" src="https://github.com/user-attachments/assets/f0b62d40-0bf1-4a3d-9f61-726601857207">

<img width="1440" alt="AI 일기 삭제" src="https://github.com/user-attachments/assets/b155b196-624d-49a8-9a5d-05b8f7507cbe">

<img width="1552" alt="db" src="https://github.com/user-attachments/assets/b43b8da0-fcaa-4855-ba02-82d895abfd68">


## 💬 리뷰 요구사항

- 현재 Diary 관련 로직은 프론트에서 테스트를 위해 `memberId`로 해두었습니다. 테스트 완료 후, 인증 객체를 사용하도록 수정할 계획입니다.
