### PR TITLE
Feat: 프롬프트 엔지니어링 추가

### DIFF
--- a/src/main/java/com/skhu/moodfriend/app/controller/friend/FriendController.java
+++ b/src/main/java/com/skhu/moodfriend/app/controller/friend/FriendController.java
@@ -44,8 +44,8 @@ public class FriendController {
 
     @GetMapping("/requests/display")
     @Operation(
-            summary = "친구 추가 요청 리스트",
-            description = "요청한 친구 리스트를 조회합니다.",
+            summary = "요청 보낸 리스트",
+            description = "요청 보낸 친구 리스트를 조회합니다.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "친구 추가 요청 리스트 조회"),
                     @ApiResponse(responseCode = "403", description = "권한 문제 or 관리자 문의"),
@@ -60,10 +60,10 @@ public class FriendController {
 
     @GetMapping("/requests/received")
     @Operation(
-            summary = "받은 친구 요청 리스트",
-            description = "받은 친구 요청 리스트를 조회합니다.",
+            summary = "요청 받은 리스트",
+            description = "요청 받은 친구 리스트를 조회합니다.",
             responses = {
-                    @ApiResponse(responseCode = "200", description = "받은 친구 요청 리스트 조회"),
+                    @ApiResponse(responseCode = "200", description = "친구 추가 요청받은 리스트 조회"),
                     @ApiResponse(responseCode = "403", description = "권한 문제 or 관리자 문의"),
                     @ApiResponse(responseCode = "404", description = "친구 정보를 찾을 수 없음"),
                     @ApiResponse(responseCode = "500", description = "서버 문제 or 관리자 문의")

--- a/src/main/java/com/skhu/moodfriend/app/repository/DiaryAIRepository.java
+++ b/src/main/java/com/skhu/moodfriend/app/repository/DiaryAIRepository.java
@@ -3,13 +3,18 @@ package com.skhu.moodfriend.app.repository;
 import com.skhu.moodfriend.app.domain.member.Member;
 import com.skhu.moodfriend.app.domain.tracker.diary_ai.DiaryAI;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public interface DiaryAIRepository extends JpaRepository<DiaryAI, Long> {
 
     List<DiaryAI> findAllByCreatedAt(LocalDate createdAt);
 
     List<DiaryAI> findByMemberOrderByCreatedAt(Member member);
+
+    @Query("SELECT d FROM DiaryAI d WHERE d.member = :member ORDER BY d.createdAt DESC")
+    Optional<DiaryAI> findTopByMemberOrderByCreatedAtDesc(Member member);
 }

--- a/src/main/java/com/skhu/moodfriend/app/service/auth/GoogleOAuthService.java
+++ b/src/main/java/com/skhu/moodfriend/app/service/auth/GoogleOAuthService.java
@@ -34,8 +34,10 @@ public class GoogleOAuthService {
     @Value("${oauth.google.client-secret}")
     private String GOOGLE_CLIENT_SECRET;
 
+    @Value("${oauth.google.redirect-uri}")
+    private String GOOGLE_REDIRECT_URI;
+
     private final String GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
-    private final String GOOGLE_REDIRECT_URI = "https://moodfriend.site/api/v1/auth/callback/google";
     private final MemberRepository memberRepository;
     private final TokenProvider tokenProvider;
 

--- a/src/main/java/com/skhu/moodfriend/app/service/auth/KakaoOAuthService.java
+++ b/src/main/java/com/skhu/moodfriend/app/service/auth/KakaoOAuthService.java
@@ -32,8 +32,10 @@ public class KakaoOAuthService {
     @Value("${oauth.kakao.client-id}")
     private String KAKAO_CLIENT_ID;
 
+    @Value("${oauth.kakao.redirect-uri}")
+    private String KAKAO_REDIRECT_URI;
+
     private final String KAKAO_TOKEN_URL = "https://kauth.kakao.com/oauth/token";
-    private final String KAKAO_REDIRECT_URI = "https://moodfriend.site/api/v1/auth/callback/kakao";
 
     private final MemberRepository memberRepository;
     private final TokenProvider tokenProvider;

--- a/src/main/java/com/skhu/moodfriend/app/service/chat/ConversationCleanupService.java
+++ b/src/main/java/com/skhu/moodfriend/app/service/chat/ConversationCleanupService.java
@@ -26,7 +26,7 @@ public class ConversationCleanupService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    @Scheduled(cron = "0 30 2 * * *")
+    @Scheduled(cron = "0 55 16 * * *")
     public void clearAndInsertSummary() {
 
         List<Member> members = memberRepository.findAll();

--- a/src/main/java/com/skhu/moodfriend/app/service/chat/ConversationCleanupService.java
+++ b/src/main/java/com/skhu/moodfriend/app/service/chat/ConversationCleanupService.java
@@ -26,7 +26,7 @@ public class ConversationCleanupService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    @Scheduled(cron = "0 15 17 * * *")
+    @Scheduled(cron = "0 30 2 * * *")
     public void clearAndInsertSummary() {
 
         List<Member> members = memberRepository.findAll();

--- a/src/main/java/com/skhu/moodfriend/app/service/chat/ConversationCleanupService.java
+++ b/src/main/java/com/skhu/moodfriend/app/service/chat/ConversationCleanupService.java
@@ -43,10 +43,20 @@ public class ConversationCleanupService {
             conversationService.clearConversation(memberId);
 
             String summary = summaries.get(memberId);
+            if (summary == null) {
+                summary = getLastSummary(member);
+            }
+
             if (summary != null) {
                 Message summaryMessage = new Message("system", summary);
                 conversationService.addMessage(memberId, summaryMessage);
             }
         }
+    }
+
+    private String getLastSummary(Member member) {
+        return diaryAIRepository.findTopByMemberOrderByCreatedAtDesc(member)
+                .map(DiaryAI::getSummary)
+                .orElse(null);
     }
 }

--- a/src/main/java/com/skhu/moodfriend/app/service/chat/ConversationCleanupService.java
+++ b/src/main/java/com/skhu/moodfriend/app/service/chat/ConversationCleanupService.java
@@ -26,7 +26,7 @@ public class ConversationCleanupService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    @Scheduled(cron = "0 55 16 * * *")
+    @Scheduled(cron = "0 15 17 * * *")
     public void clearAndInsertSummary() {
 
         List<Member> members = memberRepository.findAll();

--- a/src/main/java/com/skhu/moodfriend/app/service/chat/ConversationService.java
+++ b/src/main/java/com/skhu/moodfriend/app/service/chat/ConversationService.java
@@ -22,7 +22,9 @@ public class ConversationService {
 
     public void addMessage(Long memberId, Message message) {
         conversations.computeIfAbsent(memberId, k -> new ArrayList<>()).add(message);
-        messageTimestamps.computeIfAbsent(memberId, k -> new ArrayList<>()).add(LocalDateTime.now());
+        if ("user".equals(message.role())) {
+            messageTimestamps.computeIfAbsent(memberId, k -> new ArrayList<>()).add(LocalDateTime.now());
+        }
     }
 
     @Transactional

--- a/src/main/java/com/skhu/moodfriend/app/service/chat/ConversationService.java
+++ b/src/main/java/com/skhu/moodfriend/app/service/chat/ConversationService.java
@@ -4,6 +4,7 @@ import com.skhu.moodfriend.app.dto.chat.Message;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -13,6 +14,7 @@ import java.util.Map;
 public class ConversationService {
 
     private final Map<Long, List<Message>> conversations = new HashMap<>();
+    private final Map<Long, List<LocalDateTime>> messageTimestamps = new HashMap<>();
 
     public List<Message> getConversation(Long memberId) {
         return conversations.getOrDefault(memberId, new ArrayList<>());
@@ -20,10 +22,16 @@ public class ConversationService {
 
     public void addMessage(Long memberId, Message message) {
         conversations.computeIfAbsent(memberId, k -> new ArrayList<>()).add(message);
+        messageTimestamps.computeIfAbsent(memberId, k -> new ArrayList<>()).add(LocalDateTime.now());
     }
 
     @Transactional
     public void clearConversation(Long memberId) {
         conversations.put(memberId, new ArrayList<>());
+        messageTimestamps.put(memberId, new ArrayList<>());
+    }
+
+    public List<LocalDateTime> getMessageTimestamps(Long memberId) {
+        return messageTimestamps.getOrDefault(memberId, new ArrayList<>());
     }
 }

--- a/src/main/java/com/skhu/moodfriend/app/service/chat/ConversationSummaryService.java
+++ b/src/main/java/com/skhu/moodfriend/app/service/chat/ConversationSummaryService.java
@@ -40,7 +40,7 @@ public class ConversationSummaryService {
     private String model;
 
     @Transactional
-    @Scheduled(cron = "0 50 16 * * *")
+    @Scheduled(cron = "0 10 17 * * *")
     public void summarizeConversations() {
         List<Member> members = memberRepository.findAll();
 
@@ -49,9 +49,9 @@ public class ConversationSummaryService {
             if (hasUserMessagesToday(memberId)) {
                 List<Message> messages = conversationService.getConversation(memberId);
 
-                String prompt = "Here is the user's conversation history. Please summarize the main points of the conversation in a concise manner. The summary should not exceed 1024 characters and must include the key points and important information.";
+                String prompt = "Here is the user's conversation history. Please summarize the main points of the conversation in a concise and casual manner, as if the user is writing a diary entry. The summary should not exceed 1024 characters and must include the key points and important information.";
 
-                messages.add(new Message("user", prompt));
+                messages.add(new Message("system", prompt));
 
                 HoyaReqDto reqDto = new HoyaReqDto(model, messages);
                 HoyaResDto resDto = restTemplate.postForObject(apiURL, reqDto, HoyaResDto.class);

--- a/src/main/java/com/skhu/moodfriend/app/service/chat/ConversationSummaryService.java
+++ b/src/main/java/com/skhu/moodfriend/app/service/chat/ConversationSummaryService.java
@@ -45,6 +45,10 @@ public class ConversationSummaryService {
             Long memberId = member.getMemberId();
             List<Message> messages = conversationService.getConversation(memberId);
 
+            if (isOnlySummaryPrompt(messages)) {
+                continue;
+            }
+
             String prompt = "Here is the user's conversation history. Please summarize the main points of the conversation in a concise manner. The summary should not exceed 1024 characters and must include the key points and important information.";
 
             messages.add(new Message("user", prompt));
@@ -68,5 +72,13 @@ public class ConversationSummaryService {
 
             diaryAIRepository.save(diaryAI);
         }
+    }
+
+    private boolean isOnlySummaryPrompt(List<Message> messages) {
+        if (messages.size() == 1) {
+            Message message = messages.get(0);
+            return "user".equals(message.role()) && message.content().startsWith("Respond to the user's input as if you are their close friend");
+        }
+        return false;
     }
 }

--- a/src/main/java/com/skhu/moodfriend/app/service/chat/ConversationSummaryService.java
+++ b/src/main/java/com/skhu/moodfriend/app/service/chat/ConversationSummaryService.java
@@ -40,15 +40,15 @@ public class ConversationSummaryService {
     private String model;
 
     @Transactional
-    @Scheduled(cron = "0 0 2 * * *")
+    @Scheduled(cron = "0 50 16 * * *")
     public void summarizeConversations() {
         List<Member> members = memberRepository.findAll();
 
         for (Member member : members) {
             Long memberId = member.getMemberId();
-            List<Message> messages = conversationService.getConversation(memberId);
-
             if (hasUserMessagesToday(memberId)) {
+                List<Message> messages = conversationService.getConversation(memberId);
+
                 String prompt = "Here is the user's conversation history. Please summarize the main points of the conversation in a concise manner. The summary should not exceed 1024 characters and must include the key points and important information.";
 
                 messages.add(new Message("user", prompt));

--- a/src/main/java/com/skhu/moodfriend/app/service/chat/ConversationSummaryService.java
+++ b/src/main/java/com/skhu/moodfriend/app/service/chat/ConversationSummaryService.java
@@ -40,7 +40,7 @@ public class ConversationSummaryService {
     private String model;
 
     @Transactional
-    @Scheduled(cron = "0 10 17 * * *")
+    @Scheduled(cron = "0 0 2 * * *")
     public void summarizeConversations() {
         List<Member> members = memberRepository.findAll();
 

--- a/src/main/java/com/skhu/moodfriend/app/service/chat/HoyaService.java
+++ b/src/main/java/com/skhu/moodfriend/app/service/chat/HoyaService.java
@@ -85,7 +85,7 @@ public class HoyaService {
 
     private String generateFriendlyEmotionPrompt(String userInput, String userName) {
         return String.format(
-                "Respond to the user's input as if you are their close friend, using a very friendly and casual tone. The user's input is: \"%s\". Focus on the emotions conveyed in their message and continue the conversation in an empathetic and supportive manner. Use informal language and include the user's name, %s, to make the response feel personal and comforting. The response should be very informal, casual, and supportive, just like a close friend talking.",
+                "Respond to the user's input as if you are their close friend, using a very friendly and casual tone. The user's input is: \"%s\". Focus on the emotions conveyed in their message and continue the conversation in an empathetic and supportive manner. Use informal language and include the user's name, %s, when necessary to make the response feel personal and comforting. The response should be very informal, casual, and supportive, just like a close friend talking.",
                 userInput, userName
         );
     }

--- a/src/main/java/com/skhu/moodfriend/app/service/chat/HoyaService.java
+++ b/src/main/java/com/skhu/moodfriend/app/service/chat/HoyaService.java
@@ -49,7 +49,8 @@ public class HoyaService {
         String translatedPromptToEn = translationService.translate(emotionPrompt, "EN");
 
         List<Message> messages = new ArrayList<>(conversationService.getConversation(memberId));
-        messages.add(new Message("user", translatedPromptToEn));
+        Message userMessage = new Message("user", translatedPromptToEn);
+        conversationService.addMessage(memberId, userMessage);
 
         HoyaReqDto reqDto = new HoyaReqDto(model, messages);
         HoyaResDto resDto = restTemplate.postForObject(apiURL, reqDto, HoyaResDto.class);

--- a/src/main/java/com/skhu/moodfriend/app/service/chat/HoyaService.java
+++ b/src/main/java/com/skhu/moodfriend/app/service/chat/HoyaService.java
@@ -85,8 +85,8 @@ public class HoyaService {
 
     private String generateFriendlyEmotionPrompt(String userInput, String userName) {
         return String.format(
-                "Respond to the user's input as if you are their close friend, using a very friendly and casual tone. The user's input is: \"%s\". Focus on the emotions conveyed in their message and continue the conversation in an empathetic and supportive manner. Use informal language and include the user's name, %s, when necessary to make the response feel personal and comforting. The response should be very informal, casual, and supportive, just like a close friend talking.",
-                userInput, userName
+                "Respond to the user's input as if you are their close friend, using a very friendly and casual tone. The user's name is %s. The user's input is: \"%s\". Focus on the emotions conveyed in their message and continue the conversation in an empathetic and supportive manner. Use informal language and include the user's name only when necessary to make the response feel personal and comforting. Please do not use any emojis or symbols in the response. The response should be very informal, casual, and supportive, just like a close friend talking.",
+                userName, userInput
         );
     }
 }

--- a/src/main/java/com/skhu/moodfriend/app/service/chat/HoyaService.java
+++ b/src/main/java/com/skhu/moodfriend/app/service/chat/HoyaService.java
@@ -49,8 +49,14 @@ public class HoyaService {
         String translatedPromptToEn = translationService.translate(emotionPrompt, "EN");
 
         List<Message> messages = new ArrayList<>(conversationService.getConversation(memberId));
+
+        if (messages.isEmpty()) {
+            messages.add(new Message("system", "This is the beginning of the conversation."));
+        }
+
         Message userMessage = new Message("user", translatedPromptToEn);
         conversationService.addMessage(memberId, userMessage);
+        messages.add(userMessage);
 
         HoyaReqDto reqDto = new HoyaReqDto(model, messages);
         HoyaResDto resDto = restTemplate.postForObject(apiURL, reqDto, HoyaResDto.class);

--- a/src/main/java/com/skhu/moodfriend/app/service/chat/HoyaService.java
+++ b/src/main/java/com/skhu/moodfriend/app/service/chat/HoyaService.java
@@ -40,14 +40,13 @@ public class HoyaService {
     public ApiResponseTemplate<HoyaResDto> getResponse(String prompt, Principal principal) {
 
         Long memberId = Long.parseLong(principal.getName());
-
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_MEMBER_EXCEPTION, ErrorCode.NOT_FOUND_MEMBER_EXCEPTION.getMessage()));
 
         String userName = member.getName();
 
         String translatedPromptToEn = translationService.translate(prompt, "EN");
-        String emotionPrompt = generateEmotionPrompt(translatedPromptToEn, userName);
+        String emotionPrompt = generateFriendlyEmotionPrompt(translatedPromptToEn, userName);
 
         List<Message> messages = new ArrayList<>(conversationService.getConversation(memberId));
         messages.add(new Message("user", emotionPrompt));
@@ -77,9 +76,9 @@ public class HoyaService {
         return ApiResponseTemplate.success(SuccessCode.GET_HOYA_SUCCESS, responseDto);
     }
 
-    private String generateEmotionPrompt(String userInput, String userName) {
+    private String generateFriendlyEmotionPrompt(String userInput, String userName) {
         return String.format(
-                "The user's input is: \"%s\". Analyze the emotion conveyed and respond empathetically. Include the user's name, %s, in the response if appropriate.",
+                "Respond to the user's input as if you are their close friend, using a very friendly and casual tone. The user's input is: \"%s\". Focus on the emotions conveyed in their message and continue the conversation in an empathetic and supportive manner. Use informal language and include the user's name, %s, to make the response feel personal and comforting. The response should be very informal, casual, and supportive, just like a close friend talking.",
                 userInput, userName
         );
     }

--- a/src/main/java/com/skhu/moodfriend/app/service/chat/HoyaService.java
+++ b/src/main/java/com/skhu/moodfriend/app/service/chat/HoyaService.java
@@ -45,11 +45,11 @@ public class HoyaService {
 
         String userName = member.getName();
 
-        String translatedPromptToEn = translationService.translate(prompt, "EN");
-        String emotionPrompt = generateFriendlyEmotionPrompt(translatedPromptToEn, userName);
+        String emotionPrompt = generateFriendlyEmotionPrompt(prompt, userName);
+        String translatedPromptToEn = translationService.translate(emotionPrompt, "EN");
 
         List<Message> messages = new ArrayList<>(conversationService.getConversation(memberId));
-        messages.add(new Message("user", emotionPrompt));
+        messages.add(new Message("user", translatedPromptToEn));
 
         HoyaReqDto reqDto = new HoyaReqDto(model, messages);
         HoyaResDto resDto = restTemplate.postForObject(apiURL, reqDto, HoyaResDto.class);

--- a/src/main/java/com/skhu/moodfriend/app/service/chat/TranslationService.java
+++ b/src/main/java/com/skhu/moodfriend/app/service/chat/TranslationService.java
@@ -34,10 +34,7 @@ public class TranslationService {
     private final ObjectMapper objectMapper;
 
     public String translate(String text, String targetLang) {
-        String prompt = "다음 텍스트를 친한 친구와 대화하듯 격식을 차리지 않고 일상적인 한국어로 번역하세요: ";
-        String textWithPrompt = prompt + text;
-
-        TranslationReqDto reqDto = new TranslationReqDto(Collections.singletonList(textWithPrompt), targetLang);
+        TranslationReqDto reqDto = new TranslationReqDto(Collections.singletonList(text), targetLang);
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
@@ -59,12 +56,6 @@ public class TranslationService {
             throw new CustomException(ErrorCode.FAILED_TRANSLATION_EXCEPTION, ErrorCode.FAILED_TRANSLATION_EXCEPTION.getMessage());
         }
 
-        String translatedText = resDto.translations().get(0).text();
-
-        if (translatedText.startsWith(prompt)) {
-            translatedText = translatedText.substring(prompt.length()).trim();
-        }
-
-        return translatedText;
+        return resDto.translations().get(0).text();
     }
 }

--- a/src/main/java/com/skhu/moodfriend/app/service/chat/TranslationService.java
+++ b/src/main/java/com/skhu/moodfriend/app/service/chat/TranslationService.java
@@ -34,8 +34,7 @@ public class TranslationService {
     private final ObjectMapper objectMapper;
 
     public String translate(String text, String targetLang) {
-
-        String prompt = "친한 친구와 대화하듯 격식을 차리지 않고 일상적인 한국어로 번역하세요: ";
+        String prompt = "다음 텍스트를 친한 친구와 대화하듯 격식을 차리지 않고 일상적인 한국어로 번역하세요: ";
         String textWithPrompt = prompt + text;
 
         TranslationReqDto reqDto = new TranslationReqDto(Collections.singletonList(textWithPrompt), targetLang);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
     database: mysql
     database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,8 +28,10 @@ oauth:
   google:
     client-id: ${GOOGLE_CLIENT_ID}
     client-secret: ${GOOGLE_CLIENT_SECRET}
+    redirect-uri: ${GOOGLE_REDIRECT_URI}
   kakao:
     client-id: ${KAKAO_CLIENT_ID}
+    redirect-uri: ${KAKAO_REDIRECT_URI}
 
 kakao-map:
   client-id: ${KAKAO_CLIENT_ID}


### PR DESCRIPTION
## 🍀 관련 이슈

- Resolved: #28 


## 🌱 작업 내용

- 구현한 호야 챗봇 초기에서 프롬프트 엔지니어링을 통해 감정 관련 응답의 품질 개선
  - 사용자 입력을 감정 중심으로 분석하고, 친근하고 캐주얼한 톤으로 응답받도록 함
  - 응답에는 이모지가 포함되지 않고, 필요에 따라 사용자 이름이 포함될 수 있음
  - 사용자 입력을 타임스탬프와 함께 저장하여, 이후 대화 요약 시 당일 사용자가 입력한 메시지가 있는지 확인
  - 당일 대화 내역을 자연스러운 일기 형식으로 요약하여 DiaryAI 저장
  - 가장 최근에 저장된 DiaryAI 내용 기반으로 대화를 이어나갈 수 있도록 함


회원가입을 마친 사용자 목록입니다.

<img width="1215" alt="사용자 목록" src="https://github.com/user-attachments/assets/cb53535b-0f97-4d7d-9593-e67eb1e564f6">

`test1` 계정으로 대화

<img width="1440" alt="두오-1" src="https://github.com/user-attachments/assets/918e68ba-3e07-4f90-ad48-cb9fee0c0ec9">

<img width="1440" alt="두오-2" src="https://github.com/user-attachments/assets/c9e4e825-1e0d-444c-a6a7-feabb5fc2884">

<img width="1440" alt="두오-3" src="https://github.com/user-attachments/assets/4d299b1d-2f83-4651-a472-eecdbaadc26e">

`test2` 계정으로 대화

<img width="1440" alt="민준-1" src="https://github.com/user-attachments/assets/31145e9b-a364-4d6e-98e0-255cf9349846">

<img width="1440" alt="민준-2" src="https://github.com/user-attachments/assets/4c2b79b3-211f-4976-a78f-68f7cb15e1b2">

<img width="1440" alt="민준-3" src="https://github.com/user-attachments/assets/5807396e-0129-461e-b9ab-0d33037617c8">

`test3` 계정으로는 당일 대화를 하지 않았기에, DiaryAI 가 저장되지 않습니다.

<img width="1259" alt="DiaryAI" src="https://github.com/user-attachments/assets/b7d5fb59-aacf-4524-a9cd-13baf75eaddd">


## 💬 리뷰 요구사항

- DeepL api를 사용하다 보니, 번역 오류가 좀 있더라고..
우선 전체적으로 구현 마치고, 디테일하게 개선하면 될 거 같아
