### PR TITLE
Feat: 로그아웃, 회원탈퇴 구현

### DIFF
--- a/src/main/java/com/skhu/moodfriend/app/controller/auth/AccountController.java
+++ b/src/main/java/com/skhu/moodfriend/app/controller/auth/AccountController.java
@@ -1,0 +1,38 @@
+package com.skhu.moodfriend.app.controller.auth;
+
+import com.skhu.moodfriend.app.service.auth.LogoutService;
+import com.skhu.moodfriend.global.template.ApiResponseTemplate;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+
+@RestController
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@Tag(name = "로그아웃/회원탈퇴", description = "로그아웃/회원탈퇴를 담당하는 api 그룹")
+@RequestMapping("/api/v1/account")
+public class AccountController {
+
+    private final LogoutService logoutService;
+
+    @PostMapping("/logout")
+    @Operation(
+            summary = "로그아웃",
+            description = "사용자의 refreshToken을 삭제하여 로그아웃을 처리합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "로그아웃 성공"),
+                    @ApiResponse(responseCode = "500", description = "관리자 문의")
+            }
+    )
+    public ResponseEntity<ApiResponseTemplate<Void>> logout(Principal principal) {
+        ApiResponseTemplate<Void> response = logoutService.logout(principal);
+        return ResponseEntity.status(response.getStatus()).body(response);
+    }
+}

--- a/src/main/java/com/skhu/moodfriend/app/controller/auth/AccountController.java
+++ b/src/main/java/com/skhu/moodfriend/app/controller/auth/AccountController.java
@@ -1,6 +1,7 @@
 package com.skhu.moodfriend.app.controller.auth;
 
 import com.skhu.moodfriend.app.service.auth.LogoutService;
+import com.skhu.moodfriend.app.service.auth.WithDrawService;
 import com.skhu.moodfriend.global.template.ApiResponseTemplate;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -21,6 +22,7 @@ import java.security.Principal;
 public class AccountController {
 
     private final LogoutService logoutService;
+    private final WithDrawService withDrawService;
 
     @PostMapping("/logout")
     @Operation(
@@ -33,6 +35,20 @@ public class AccountController {
     )
     public ResponseEntity<ApiResponseTemplate<Void>> logout(Principal principal) {
         ApiResponseTemplate<Void> response = logoutService.logout(principal);
+        return ResponseEntity.status(response.getStatus()).body(response);
+    }
+
+    @PostMapping("/withdraw")
+    @Operation(
+            summary = "회원탈퇴",
+            description = "사용자의 계정을 삭제하고, 소셜의 경우 연결을 해제합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "회원탈퇴 성공"),
+                    @ApiResponse(responseCode = "500", description = "관리자 문의")
+            }
+    )
+    public ResponseEntity<ApiResponseTemplate<Void>> withdraw(Principal principal) {
+        ApiResponseTemplate<Void> response = withDrawService.withdraw(principal);
         return ResponseEntity.status(response.getStatus()).body(response);
     }
 }

--- a/src/main/java/com/skhu/moodfriend/app/service/auth/LogoutService.java
+++ b/src/main/java/com/skhu/moodfriend/app/service/auth/LogoutService.java
@@ -1,5 +1,7 @@
 package com.skhu.moodfriend.app.service.auth;
 
+import com.skhu.moodfriend.app.domain.member.LoginType;
+import com.skhu.moodfriend.app.domain.member.Member;
 import com.skhu.moodfriend.app.repository.MemberRefreshTokenRepository;
 import com.skhu.moodfriend.app.repository.MemberRepository;
 import com.skhu.moodfriend.global.exception.CustomException;
@@ -8,10 +10,18 @@ import com.skhu.moodfriend.global.exception.code.SuccessCode;
 import com.skhu.moodfriend.global.template.ApiResponseTemplate;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
 
 import java.security.Principal;
+import java.util.HashMap;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
@@ -20,16 +30,76 @@ public class LogoutService {
     private final MemberRefreshTokenRepository memberRefreshTokenRepository;
     private final MemberRepository memberRepository;
 
+    @Value("${oauth.google.logout-url}")
+    private String googleLogoutUrl;
+
+    @Value("${oauth.kakao.admin-key}")
+    private String kakaoAdminKey;
+
     @Transactional
     public ApiResponseTemplate<Void> logout(Principal principal) {
         Long memberId = Long.parseLong(principal.getName());
 
-        memberRepository.findById(memberId)
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_MEMBER_EXCEPTION, ErrorCode.NOT_FOUND_MEMBER_EXCEPTION.getMessage()));
+        LoginType loginType = member.getLoginType();
 
         memberRefreshTokenRepository.findByMember_MemberId(memberId)
                 .ifPresent(memberRefreshTokenRepository::delete);
 
+        if (principal instanceof Authentication) {
+            String accessToken = extractAccessToken((Authentication) principal);
+
+            if (accessToken != null) {
+                switch (loginType) {
+                    case GOOGLE_LOGIN:
+                        logoutFromGoogle(accessToken);
+                        break;
+                    case KAKAO_LOGIN:
+                        logoutFromKakao(memberId);
+                        break;
+                    case NATIVE_LOGIN:
+                        break;
+                }
+            }
+        }
+
         return ApiResponseTemplate.success(SuccessCode.LOGOUT_MEMBER_SUCCESS, null);
+    }
+
+    private String extractAccessToken(Authentication authentication) {
+        Object credentials = authentication.getCredentials();
+        if (credentials instanceof Jwt) {
+            return ((Jwt) credentials).getTokenValue();
+        }
+        return null;
+    }
+
+    private void logoutFromGoogle(String accessToken) {
+        RestTemplate restTemplate = new RestTemplate();
+        try {
+            restTemplate.postForEntity(googleLogoutUrl + accessToken, null, String.class);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.FAILED_LOGOUT_EXCEPTION, ErrorCode.FAILED_LOGOUT_EXCEPTION.getMessage());
+        }
+    }
+
+    private void logoutFromKakao(Long memberId) {
+        RestTemplate restTemplate = new RestTemplate();
+        try {
+            String kakaoLogoutUrl = "https://kapi.kakao.com/v1/user/logout";
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Authorization", "KakaoAK " + kakaoAdminKey);
+            headers.set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+
+            Map<String, Object> params = new HashMap<>();
+            params.put("target_id_type", "user_id");
+            params.put("target_id", memberId);
+
+            HttpEntity<Map<String, Object>> request = new HttpEntity<>(params, headers);
+            restTemplate.postForEntity(kakaoLogoutUrl, request, String.class);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.FAILED_LOGOUT_EXCEPTION, ErrorCode.FAILED_LOGOUT_EXCEPTION.getMessage());
+        }
     }
 }

--- a/src/main/java/com/skhu/moodfriend/app/service/auth/LogoutService.java
+++ b/src/main/java/com/skhu/moodfriend/app/service/auth/LogoutService.java
@@ -1,0 +1,35 @@
+package com.skhu.moodfriend.app.service.auth;
+
+import com.skhu.moodfriend.app.repository.MemberRefreshTokenRepository;
+import com.skhu.moodfriend.app.repository.MemberRepository;
+import com.skhu.moodfriend.global.exception.CustomException;
+import com.skhu.moodfriend.global.exception.code.ErrorCode;
+import com.skhu.moodfriend.global.exception.code.SuccessCode;
+import com.skhu.moodfriend.global.template.ApiResponseTemplate;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.Principal;
+
+@Service
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class LogoutService {
+
+    private final MemberRefreshTokenRepository memberRefreshTokenRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public ApiResponseTemplate<Void> logout(Principal principal) {
+        Long memberId = Long.parseLong(principal.getName());
+
+        memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_MEMBER_EXCEPTION, ErrorCode.NOT_FOUND_MEMBER_EXCEPTION.getMessage()));
+
+        memberRefreshTokenRepository.findByMember_MemberId(memberId)
+                .ifPresent(memberRefreshTokenRepository::delete);
+
+        return ApiResponseTemplate.success(SuccessCode.LOGOUT_MEMBER_SUCCESS, null);
+    }
+}

--- a/src/main/java/com/skhu/moodfriend/app/service/auth/WithDrawService.java
+++ b/src/main/java/com/skhu/moodfriend/app/service/auth/WithDrawService.java
@@ -1,0 +1,109 @@
+package com.skhu.moodfriend.app.service.auth;
+
+import com.skhu.moodfriend.app.domain.member.LoginType;
+import com.skhu.moodfriend.app.domain.member.Member;
+import com.skhu.moodfriend.app.repository.MemberRefreshTokenRepository;
+import com.skhu.moodfriend.app.repository.MemberRepository;
+import com.skhu.moodfriend.global.exception.CustomException;
+import com.skhu.moodfriend.global.exception.code.ErrorCode;
+import com.skhu.moodfriend.global.exception.code.SuccessCode;
+import com.skhu.moodfriend.global.template.ApiResponseTemplate;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import java.security.Principal;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class WithDrawService {
+
+    private final MemberRefreshTokenRepository memberRefreshTokenRepository;
+    private final MemberRepository memberRepository;
+
+    @Value("${oauth.google.revoke-url}")
+    private String googleRevokeUrl;
+
+    @Value("${oauth.kakao.admin-key}")
+    private String kakaoAdminKey;
+
+    @Transactional
+    public ApiResponseTemplate<Void> withdraw(Principal principal) {
+        Long memberId = Long.parseLong(principal.getName());
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_MEMBER_EXCEPTION, ErrorCode.NOT_FOUND_MEMBER_EXCEPTION.getMessage()));
+        LoginType loginType = member.getLoginType();
+
+        memberRefreshTokenRepository.findByMember_MemberId(memberId)
+                .ifPresent(memberRefreshTokenRepository::delete);
+
+        if (principal instanceof Authentication) {
+            String accessToken = extractAccessToken((Authentication) principal);
+
+            if (accessToken != null) {
+                switch (loginType) {
+                    case GOOGLE_LOGIN:
+                        revokeGoogleAccess(accessToken);
+                        break;
+                    case KAKAO_LOGIN:
+                        unlinkKakaoAccount(memberId);
+                        break;
+                    case NATIVE_LOGIN:
+                        break;
+                }
+            }
+        }
+
+        memberRepository.delete(member);
+
+        return ApiResponseTemplate.success(SuccessCode.WITHDRAW_MEMBER_SUCCESS, null);
+    }
+
+    private String extractAccessToken(Authentication authentication) {
+        Object credentials = authentication.getCredentials();
+        if (credentials instanceof Jwt) {
+            return ((Jwt) credentials).getTokenValue();
+        }
+        return null;
+    }
+
+    private void revokeGoogleAccess(String accessToken) {
+        RestTemplate restTemplate = new RestTemplate();
+        try {
+            String url = googleRevokeUrl + "?token=" + accessToken;
+            restTemplate.exchange(url, HttpMethod.POST, null, String.class);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.FAILED_WITHDRAW_EXCEPTION, ErrorCode.FAILED_WITHDRAW_EXCEPTION.getMessage());
+        }
+    }
+
+    private void unlinkKakaoAccount(Long memberId) {
+        RestTemplate restTemplate = new RestTemplate();
+        try {
+            String kakaoUnlinkUrl = "https://kapi.kakao.com/v1/user/unlink";
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Authorization", "KakaoAK " + kakaoAdminKey);
+            headers.set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+
+            Map<String, Object> params = new HashMap<>();
+            params.put("target_id_type", "user_id");
+            params.put("target_id", memberId);
+
+            HttpEntity<Map<String, Object>> request = new HttpEntity<>(params, headers);
+            restTemplate.postForEntity(kakaoUnlinkUrl, request, String.class);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.FAILED_WITHDRAW_EXCEPTION, ErrorCode.FAILED_WITHDRAW_EXCEPTION.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/skhu/moodfriend/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/skhu/moodfriend/global/exception/code/ErrorCode.java
@@ -51,7 +51,8 @@ public enum ErrorCode {
     FAILED_GET_TOKEN_EXCEPTION(HttpStatus.SERVICE_UNAVAILABLE, "토큰을 가져오는 중 오류가 발생했습니다."),
     FAILED_TRANSLATION_EXCEPTION(HttpStatus.SERVICE_UNAVAILABLE, "번역하는 중 오류가 발생했습니다."),
     FAILED_GET_GPT_RESPONSE_EXCEPTION(HttpStatus.SERVICE_UNAVAILABLE, "챗봇 응답 중 오류가 발생했습니다."),
-    FAILED_ORDER_SAVE_EXCEPTION(HttpStatus.SERVICE_UNAVAILABLE, "주문 중 오류가 발생했습니다.");
+    FAILED_ORDER_SAVE_EXCEPTION(HttpStatus.SERVICE_UNAVAILABLE, "주문 중 오류가 발생했습니다."),
+    FAILED_LOGOUT_EXCEPTION(HttpStatus.SERVICE_UNAVAILABLE, "로그아웃 중 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/skhu/moodfriend/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/skhu/moodfriend/global/exception/code/ErrorCode.java
@@ -52,7 +52,8 @@ public enum ErrorCode {
     FAILED_TRANSLATION_EXCEPTION(HttpStatus.SERVICE_UNAVAILABLE, "번역하는 중 오류가 발생했습니다."),
     FAILED_GET_GPT_RESPONSE_EXCEPTION(HttpStatus.SERVICE_UNAVAILABLE, "챗봇 응답 중 오류가 발생했습니다."),
     FAILED_ORDER_SAVE_EXCEPTION(HttpStatus.SERVICE_UNAVAILABLE, "주문 중 오류가 발생했습니다."),
-    FAILED_LOGOUT_EXCEPTION(HttpStatus.SERVICE_UNAVAILABLE, "로그아웃 중 오류가 발생했습니다.");
+    FAILED_LOGOUT_EXCEPTION(HttpStatus.SERVICE_UNAVAILABLE, "로그아웃 중 오류가 발생했습니다."),
+    FAILED_WITHDRAW_EXCEPTION(HttpStatus.SERVICE_UNAVAILABLE, "회원탈퇴 중 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/skhu/moodfriend/global/exception/code/SuccessCode.java
+++ b/src/main/java/com/skhu/moodfriend/global/exception/code/SuccessCode.java
@@ -13,6 +13,7 @@ public enum SuccessCode {
     GET_TOKEN_SUCCESS(HttpStatus.OK, "Access 토큰을 성공적으로 가져왔습니다."),
     LOGIN_MEMBER_SUCCESS(HttpStatus.OK, "로그인에 성공했습니다."),
     LOGOUT_MEMBER_SUCCESS(HttpStatus.OK, "로그아웃에 성공했습니다."),
+    WITHDRAW_MEMBER_SUCCESS(HttpStatus.OK, "회원탈퇴에 성공했습니다."),
     GET_MEMBER_INFO_SUCCESS(HttpStatus.OK, "사용자 정보 조회에 성공했습니다."),
     UPDATE_MEMBER_INFO_SUCCESS(HttpStatus.OK, "사용자 정보 수정에 성공했습니다."),
     GET_DIARY_SUCCESS(HttpStatus.OK, "일기 조회에 성공했습니다."),

--- a/src/main/java/com/skhu/moodfriend/global/exception/code/SuccessCode.java
+++ b/src/main/java/com/skhu/moodfriend/global/exception/code/SuccessCode.java
@@ -12,6 +12,7 @@ public enum SuccessCode {
     // 200 OK
     GET_TOKEN_SUCCESS(HttpStatus.OK, "Access 토큰을 성공적으로 가져왔습니다."),
     LOGIN_MEMBER_SUCCESS(HttpStatus.OK, "로그인에 성공했습니다."),
+    LOGOUT_MEMBER_SUCCESS(HttpStatus.OK, "로그아웃에 성공했습니다."),
     GET_MEMBER_INFO_SUCCESS(HttpStatus.OK, "사용자 정보 조회에 성공했습니다."),
     UPDATE_MEMBER_INFO_SUCCESS(HttpStatus.OK, "사용자 정보 수정에 성공했습니다."),
     GET_DIARY_SUCCESS(HttpStatus.OK, "일기 조회에 성공했습니다."),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
     database: mysql
     database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,7 @@ oauth:
     client-secret: ${GOOGLE_CLIENT_SECRET}
     redirect-uri: ${GOOGLE_REDIRECT_URI}
     logout-url: ${GOOGLE_LOGOUT_URL}
+    revoke-url: ${GOOGLE_REVOKE_URL}
   kakao:
     client-id: ${KAKAO_CLIENT_ID}
     redirect-uri: ${KAKAO_REDIRECT_URI}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,9 +29,11 @@ oauth:
     client-id: ${GOOGLE_CLIENT_ID}
     client-secret: ${GOOGLE_CLIENT_SECRET}
     redirect-uri: ${GOOGLE_REDIRECT_URI}
+    logout-url: ${GOOGLE_LOGOUT_URL}
   kakao:
     client-id: ${KAKAO_CLIENT_ID}
     redirect-uri: ${KAKAO_REDIRECT_URI}
+    admin-key: ${KAKAO_ADMIN_KEY}
 
 kakao-map:
   client-id: ${KAKAO_CLIENT_ID}


### PR DESCRIPTION
## 🍀 관련 이슈

- Resolved: #51


## 🌱 작업 내용

- 로그아웃, 회원탈퇴 구현

자체, 구글, 카카오 로그인 계정을 각 하나씩 회원가입 시켰습니다.

<img width="1259" alt="초기 member" src="https://github.com/user-attachments/assets/f5b7d8c1-ef75-42a5-aaa6-2d9cda87d514">

<img width="1259" alt="초기 member_refresh_token" src="https://github.com/user-attachments/assets/c0515729-4de6-404c-b96b-3d015d573beb">


자체 로그인 계정은 로그아웃을 했고, 카카오 계정을 회원탈퇴를 했습니다.

<img width="1440" alt="자체 로그아웃" src="https://github.com/user-attachments/assets/3138f036-940b-447c-a49a-b2df73b7c22e">

<img width="1440" alt="카카오 회원탈퇴" src="https://github.com/user-attachments/assets/f97546ae-38e7-4493-9310-167c7510e015">

로그아웃은 refresh_token 값만 삭제되는 반면, 회원탈퇴는 사용자 DB가 모두 삭제됩니다.

<img width="1259" alt="member" src="https://github.com/user-attachments/assets/87126643-4508-4898-9458-2e1c210be473">

<img width="1259" alt="member_refresh_token" src="https://github.com/user-attachments/assets/53dfbfd3-37be-424a-8aaa-a75e4aa633d1">



## 💬 리뷰 요구사항

- 관련해서 찾아보니 refresh token을 redis로 저장하고 관리한다더라구,
지금은 DB에 저장하고 관리하지만.. 추후에 공부하고 사용해보면 좋을 것 같아
